### PR TITLE
Add _FillValue Attribute example

### DIFF
--- a/netcdf/example_test.go
+++ b/netcdf/example_test.go
@@ -34,6 +34,19 @@ func CreateExampleFile(filename string) error {
 		return err
 	}
 
+	// Add a _FillValue to the variable's attributes
+	// From C++ netCDF documentation:
+	//   With netCDF-4 files, nc_put_att will notice if you are writing a _FillValue attribute,
+	//   and will tell the HDF5 layer to use the specified fill value for that variable. With
+	//   either classic or netCDF-4 files, a _FillValue attribute will be checked for validity,
+	//   to make sure it has only one value and that its type matches the type of the associated
+	//   variable.
+	fillValue := make([]uint8, 1)
+	fillValue[0] = 99
+	if err := v.Attr("_FillValue").WriteUint8s(fillValue); err != nil {
+		return err
+	}
+	
 	// Add an attribute to the variable
 	if err := v.Attr("year").WriteInt32s([]int32{2012}); err != nil {
 		return err

--- a/netcdf/example_test.go
+++ b/netcdf/example_test.go
@@ -46,7 +46,7 @@ func CreateExampleFile(filename string) error {
 	if err := v.Attr("_FillValue").WriteUint8s(fillValue); err != nil {
 		return err
 	}
-	
+
 	// Add an attribute to the variable
 	if err := v.Attr("year").WriteInt32s([]int32{2012}); err != nil {
 		return err


### PR DESCRIPTION
As attribute _FillValue is a special case, added example and C++ netCDF documentation excerpt.

I've spent way too much time figuring this one out, so if adding it to the example can save someone else time, it would at least be that !