### PR TITLE
Add ability to write/read using coordinates (incl. tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+gopher.nc
+test.nc
+main.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.1
   - 1.2
   - 1.3
+  - 1.10
 
 before_install:
   - sudo apt-get update -q -y

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,2 @@
+# TODO
+- Use Pointer in method declaration instead of actual Variable [see](https://dave.cheney.net/2016/03/19/should-methods-be-declared-on-t-or-t)

--- a/netcdf/const.go
+++ b/netcdf/const.go
@@ -33,6 +33,7 @@ const (
 // Type is a netCDF external data type.
 type Type C.nc_type
 
+// Type declarations according to C standards
 const (
 	BYTE   Type = C.NC_BYTE   // signed 1 byte integer
 	CHAR   Type = C.NC_CHAR   // ISO/ASCII character

--- a/netcdf/datasets.go
+++ b/netcdf/datasets.go
@@ -42,7 +42,7 @@ func CreateFile(path string, mode FileMode) (ds Dataset, err error) {
 	return
 }
 
-// OpenFile opens an existing nefCDF dataset file at path.
+// OpenFile opens an existing netCDF dataset file at path.
 // Mode is a bitwise-or of FileMode values.
 func OpenFile(path string, mode FileMode) (ds Dataset, err error) {
 	cpath := C.CString(path)

--- a/netcdf/datasets_test.go
+++ b/netcdf/datasets_test.go
@@ -585,6 +585,7 @@ func testReadFileViaIdx(t *testing.T, filename string, ft *FileTest) {
 		t.Fatalf("Close failed: %v\n", err)
 	}
 }
+
 func TestAt(t *testing.T) {
 	for _, ft := range fileTests {
 		f, err := ioutil.TempFile("", "netcdf_test")

--- a/netcdf/datasets_test.go
+++ b/netcdf/datasets_test.go
@@ -388,13 +388,12 @@ func TestVersion(t *testing.T) {
 
 func TestProduct(t *testing.T) {
 	results := []struct {
-		expected int
-		shape    []int
+		expected uint64
+		shape    []uint64
 	}{
-		{24, []int{4, 6}},
-		{0, []int{0, 2, 6}},
-		{8064, []int{4, 2, 4, 21, 12}},
-		{-9157104, []int{4, 123, 141, -22, 6}},
+		{24, []uint64{4, 6}},
+		{0, []uint64{0, 2, 6}},
+		{8064, []uint64{4, 2, 4, 21, 12}},
 	}
 
 	for _, test := range results {
@@ -408,16 +407,16 @@ func TestProduct(t *testing.T) {
 
 func TestValidUnravel(t *testing.T) {
 	tests := []struct {
-		idx      int
-		shape    []int
-		expected []int
+		idx      uint64
+		shape    []uint64
+		expected []uint64
 	}{
-		{4, []int{1, 5, 3}, []int{0, 1, 1}},
-		{1021, []int{12, 421, 25}, []int{0, 40, 21}},
-		{211, []int{24, 11, 5}, []int{3, 9, 1}},
-		{12, []int{12, 5}, []int{2, 2}},
-		{1412, []int{125231}, []int{1412}},
-		{122, []int{1321, 123, 12}, []int{0, 10, 2}},
+		{4, []uint64{1, 5, 3}, []uint64{0, 1, 1}},
+		{1021, []uint64{12, 421, 25}, []uint64{0, 40, 21}},
+		{211, []uint64{24, 11, 5}, []uint64{3, 9, 1}},
+		{12, []uint64{12, 5}, []uint64{2, 2}},
+		{1412, []uint64{125231}, []uint64{1412}},
+		{122, []uint64{1321, 123, 12}, []uint64{0, 10, 2}},
 	}
 
 	for _, test := range tests {
@@ -434,14 +433,14 @@ func TestValidUnravel(t *testing.T) {
 
 func TestUnravelErrors(t *testing.T) {
 	type IdxTests struct {
-		idx      int
-		shape    []int
-		expected []int
+		idx      uint64
+		shape    []uint64
+		expected []uint64
 	}
 
 	var zeros = []IdxTests{
-		{12, []int{3, 0}, nil},
-		{2, []int{0, 3}, nil},
+		{12, []uint64{3, 0}, nil},
+		{2, []uint64{0, 3}, nil},
 	}
 
 	for _, test := range zeros {
@@ -452,8 +451,8 @@ func TestUnravelErrors(t *testing.T) {
 	}
 
 	var tooBig = []IdxTests{
-		{241, []int{3, 5}, nil},
-		{221, []int{2, 3}, nil},
+		{241, []uint64{3, 5}, nil},
+		{221, []uint64{2, 3}, nil},
 	}
 
 	for _, test := range tooBig {

--- a/netcdf/datasets_test.go
+++ b/netcdf/datasets_test.go
@@ -397,9 +397,8 @@ func TestProduct(t *testing.T) {
 	}
 
 	for _, test := range results {
-		var result = product(test.shape)
-		if result != test.expected {
-			t.Errorf("Result of 'product(%v)' is %v, expected %v", test.shape, result, test.expected)
+		if p := product(test.shape); p != test.expected {
+			t.Errorf("Result of 'product(%v)' is %v, expected %v", test.shape, p, test.expected)
 		}
 	}
 
@@ -420,7 +419,7 @@ func TestValidUnravel(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		var result, err = UnravelIndex(test.idx, test.shape)
+		result, err := UnravelIndex(test.idx, test.shape)
 		if err != nil {
 			t.Errorf("Got error while reading valid test, got %v", err)
 		}
@@ -488,27 +487,27 @@ func testWriteFileViaIdx(t *testing.T, filename string, ft *FileTest) {
 	default:
 		t.Fatalf("unexpected type %v\n", ft.DataType)
 	case UINT64:
-		err = testWriteUint64Idx(v, n)
+		err = testWriteUint64At(v, n)
 	case INT64:
-		err = testWriteInt64Idx(v, n)
+		err = testWriteInt64At(v, n)
 	case DOUBLE:
-		err = testWriteFloat64Idx(v, n)
+		err = testWriteFloat64At(v, n)
 	case UINT:
-		err = testWriteUint32Idx(v, n)
+		err = testWriteUint32At(v, n)
 	case INT:
-		err = testWriteInt32Idx(v, n)
+		err = testWriteInt32At(v, n)
 	case FLOAT:
-		err = testWriteFloat32Idx(v, n)
+		err = testWriteFloat32At(v, n)
 	case USHORT:
-		err = testWriteUint16Idx(v, n)
+		err = testWriteUint16At(v, n)
 	case SHORT:
-		err = testWriteInt16Idx(v, n)
+		err = testWriteInt16At(v, n)
 	case UBYTE:
-		err = testWriteUint8Idx(v, n)
+		err = testWriteUint8At(v, n)
 	case BYTE:
-		err = testWriteInt8Idx(v, n)
+		err = testWriteInt8At(v, n)
 	case CHAR:
-		err = testWriteBytesIdx(v, n)
+		err = testWriteBytesAt(v, n)
 	}
 	if err != nil {
 		t.Errorf("%v: writing data failed: %v\n", ft.DataType, err)
@@ -557,27 +556,27 @@ func testReadFileViaIdx(t *testing.T, filename string, ft *FileTest) {
 	default:
 		t.Fatalf("unexpected type %v\n", ft.DataType)
 	case UINT64:
-		err = testReadUint64Idx(v, n)
+		err = testReadUint64At(v, n)
 	case INT64:
-		err = testReadInt64Idx(v, n)
+		err = testReadInt64At(v, n)
 	case DOUBLE:
-		err = testReadFloat64Idx(v, n)
+		err = testReadFloat64At(v, n)
 	case UINT:
-		err = testReadUint32Idx(v, n)
+		err = testReadUint32At(v, n)
 	case INT:
-		err = testReadInt32Idx(v, n)
+		err = testReadInt32At(v, n)
 	case FLOAT:
-		err = testReadFloat32Idx(v, n)
+		err = testReadFloat32At(v, n)
 	case USHORT:
-		err = testReadUint16Idx(v, n)
+		err = testReadUint16At(v, n)
 	case SHORT:
-		err = testReadInt16Idx(v, n)
+		err = testReadInt16At(v, n)
 	case UBYTE:
-		err = testReadUint8Idx(v, n)
+		err = testReadUint8At(v, n)
 	case BYTE:
-		err = testReadInt8Idx(v, n)
+		err = testReadInt8At(v, n)
 	case CHAR:
-		err = testReadBytesIdx(v, n)
+		err = testReadBytesAt(v, n)
 	}
 	if err != nil {
 		t.Fatalf("reading data failed: %v\n", err)
@@ -586,7 +585,7 @@ func testReadFileViaIdx(t *testing.T, filename string, ft *FileTest) {
 		t.Fatalf("Close failed: %v\n", err)
 	}
 }
-func TestIdx(t *testing.T) {
+func TestAt(t *testing.T) {
 	for _, ft := range fileTests {
 		f, err := ioutil.TempFile("", "netcdf_test")
 		if err != nil {

--- a/netcdf/generate.go
+++ b/netcdf/generate.go
@@ -40,8 +40,10 @@ var TheFile = File{
 		"C.double",
 		"C.nc_get_att_double",
 		"C.nc_get_var_double",
+		"C.nc_get_var1_double",
 		"C.nc_put_att_double",
 		"C.nc_put_var_double",
+		"C.nc_put_var1_double",
 	},
 	DocIdents: []string{
 		"testReadFloat64s",
@@ -50,8 +52,10 @@ var TheFile = File{
 		"GetFloat64s",
 		"ReadFloat64s",
 		"WriteFloat64s",
+		"ReadIdxFloat64",
+		"WriteIdxFloat64",
 	},
-	Keys: []string{"float64", "Float64s", "DOUBLE", "C.double", "_double"},
+	Keys: []string{"float64", "Float64s", "DOUBLE", "Float64", "C.double", "_double"},
 }
 
 // OutFiles are the files that needs to be generated from TheFile.
@@ -64,43 +68,43 @@ var TheFile = File{
 var OutFiles = []File{
 	{
 		Name: "nc_uint64.go",
-		Keys: []string{"uint64", "Uint64s", "UINT64", "C.ulonglong", "_ulonglong"},
+		Keys: []string{"uint64", "Uint64s", "UINT64", "Uint64", "C.ulonglong", "_ulonglong"},
 	},
 	{
 		Name: "nc_int64.go",
-		Keys: []string{"int64", "Int64s", "INT64", "C.longlong", "_longlong"},
+		Keys: []string{"int64", "Int64s", "INT64", "Int64", "C.longlong", "_longlong"},
 	},
 	{
 		Name: "nc_uint.go",
-		Keys: []string{"uint32", "Uint32s", "UINT", "C.uint", "_uint"},
+		Keys: []string{"uint32", "Uint32s", "UINT", "Uint32", "C.uint", "_uint"},
 	},
 	{
 		Name: "nc_int.go",
-		Keys: []string{"int32", "Int32s", "INT", "C.int", "_int"},
+		Keys: []string{"int32", "Int32s", "INT", "Int32", "C.int", "_int"},
 	},
 	{
 		Name: "nc_float.go",
-		Keys: []string{"float32", "Float32s", "FLOAT", "C.float", "_float"},
+		Keys: []string{"float32", "Float32s", "FLOAT", "Float32", "C.float", "_float"},
 	},
 	{
 		Name: "nc_ushort.go",
-		Keys: []string{"uint16", "Uint16s", "USHORT", "C.ushort", "_ushort"},
+		Keys: []string{"uint16", "Uint16s", "USHORT", "Uint16", "C.ushort", "_ushort"},
 	},
 	{
 		Name: "nc_short.go",
-		Keys: []string{"int16", "Int16s", "SHORT", "C.short", "_short"},
+		Keys: []string{"int16", "Int16s", "SHORT", "Int16", "C.short", "_short"},
 	},
 	{
 		Name: "nc_ubyte.go",
-		Keys: []string{"uint8", "Uint8s", "UBYTE", "C.uchar", "_uchar"},
+		Keys: []string{"uint8", "Uint8s", "UBYTE", "Uint8", "C.uchar", "_uchar"},
 	},
 	{
 		Name: "nc_byte.go",
-		Keys: []string{"int8", "Int8s", "BYTE", "C.schar", "_schar"},
+		Keys: []string{"int8", "Int8s", "BYTE", "Int8", "C.schar", "_schar"},
 	},
 	{
 		Name: "nc_char.go",
-		Keys: []string{"byte", "Bytes", "CHAR", "C.char", "_text"},
+		Keys: []string{"byte", "Bytes", "CHAR", "Bytes", "C.char", "_text"},
 	},
 }
 

--- a/netcdf/generate.go
+++ b/netcdf/generate.go
@@ -48,14 +48,14 @@ var TheFile = File{
 	DocIdents: []string{
 		"testReadFloat64s",
 		"testWriteFloat64s",
-		"testWriteFloat64Idx",
-		"testReadFloat64Idx",
+		"testWriteFloat64At",
+		"testReadFloat64At",
 		"Float64sReader",
 		"GetFloat64s",
 		"ReadFloat64s",
 		"WriteFloat64s",
-		"ReadIdxFloat64",
-		"WriteIdxFloat64",
+		"ReadFloat64At",
+		"WriteFloat64At",
 	},
 	Keys: []string{"float64", "Float64s", "DOUBLE", "Float64", "C.double", "_double"},
 }

--- a/netcdf/generate.go
+++ b/netcdf/generate.go
@@ -48,6 +48,8 @@ var TheFile = File{
 	DocIdents: []string{
 		"testReadFloat64s",
 		"testWriteFloat64s",
+		"testWriteFloat64Idx",
+		"testReadFloat64Idx",
 		"Float64sReader",
 		"GetFloat64s",
 		"ReadFloat64s",

--- a/netcdf/nc_byte.go
+++ b/netcdf/nc_byte.go
@@ -56,14 +56,14 @@ func (a Attr) ReadInt8s(val []int8) (err error) {
 }
 
 // ReadIdxInt8 returns a value via index position
-func (v Var) ReadIdxInt8(idx []int) (val int8, err error) {
+func (v Var) ReadIdxInt8(idx []uint64) (val int8, err error) {
 	err = newError(C.nc_get_var1_schar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxInt8 sets a value via its index position
-func (v Var) WriteIdxInt8(idx []int, val int8) (err error) {
+func (v Var) WriteIdxInt8(idx []uint64, val int8) (err error) {
 	err = newError(C.nc_put_var1_schar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadInt8Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int8(i + 10)
 		val, _ := v.ReadIdxInt8(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadInt8Idx(v Var, n uint64) error {
 func testWriteInt8Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxInt8(coord, int8(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxInt8(coord)
 		if val != int8(i) {

--- a/netcdf/nc_byte.go
+++ b/netcdf/nc_byte.go
@@ -111,3 +111,46 @@ func testReadInt8s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadInt8Idx(v Var, n uint64) error {
+	data := make([]int8, n)
+	if err := v.ReadInt8s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := int8(i + 10)
+		val, _ := v.ReadIdxInt8(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteInt8Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxInt8(coord, int8(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxInt8(coord)
+		if val != int8(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_byte.go
+++ b/netcdf/nc_byte.go
@@ -55,15 +55,15 @@ func (a Attr) ReadInt8s(val []int8) (err error) {
 	return
 }
 
-// ReadIdxInt8 returns a value via index position
-func (v Var) ReadIdxInt8(idx []uint64) (val int8, err error) {
+// ReadInt8At returns a value via index position
+func (v Var) ReadInt8At(idx []uint64) (val int8, err error) {
 	err = newError(C.nc_get_var1_schar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxInt8 sets a value via its index position
-func (v Var) WriteIdxInt8(idx []uint64, val int8) (err error) {
+// WriteInt8At sets a value via its index position
+func (v Var) WriteInt8At(idx []uint64, val int8) (err error) {
 	err = newError(C.nc_put_var1_schar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadInt8s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadInt8Idx(v Var, n uint64) error {
+func testReadInt8At(v Var, n uint64) error {
 	data := make([]int8, n)
 	if err := v.ReadInt8s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadInt8Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int8(i + 10)
-		val, _ := v.ReadIdxInt8(coords)
+		val, _ := v.ReadInt8At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadInt8Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteInt8Idx(v Var, n uint64) error {
+func testWriteInt8At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteInt8Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxInt8(coord, int8(i))
+		v.WriteInt8At(coord, int8(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxInt8(coord)
+		val, _ := v.ReadInt8At(coord)
 		if val != int8(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_byte.go
+++ b/netcdf/nc_byte.go
@@ -55,6 +55,20 @@ func (a Attr) ReadInt8s(val []int8) (err error) {
 	return
 }
 
+// ReadIdxInt8 returns a value via index position
+func (v Var) ReadIdxInt8(idx []int) (val int8, err error) {
+	err = newError(C.nc_get_var1_schar(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxInt8 sets a value via its index position
+func (v Var) WriteIdxInt8(idx []int, val int8) (err error) {
+	err = newError(C.nc_put_var1_schar(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
+	return
+}
+
 // Int8sReader is a interface that allows reading a sequence of values of fixed length.
 type Int8sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadInt8s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := int8(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_char.go
+++ b/netcdf/nc_char.go
@@ -111,3 +111,46 @@ func testReadBytes(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadBytesIdx(v Var, n uint64) error {
+	data := make([]byte, n)
+	if err := v.ReadBytes(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := byte(i + 10)
+		val, _ := v.ReadIdxBytes(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteBytesIdx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxBytes(coord, byte(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxBytes(coord)
+		if val != byte(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_char.go
+++ b/netcdf/nc_char.go
@@ -55,6 +55,20 @@ func (a Attr) ReadBytes(val []byte) (err error) {
 	return
 }
 
+// ReadIdxBytes returns a value via index position
+func (v Var) ReadIdxBytes(idx []int) (val byte, err error) {
+	err = newError(C.nc_get_var1_text(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxBytes sets a value via its index position
+func (v Var) WriteIdxBytes(idx []int, val byte) (err error) {
+	err = newError(C.nc_put_var1_text(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
+	return
+}
+
 // BytesReader is a interface that allows reading a sequence of values of fixed length.
 type BytesReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadBytes(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := byte(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_char.go
+++ b/netcdf/nc_char.go
@@ -56,14 +56,14 @@ func (a Attr) ReadBytes(val []byte) (err error) {
 }
 
 // ReadIdxBytes returns a value via index position
-func (v Var) ReadIdxBytes(idx []int) (val byte, err error) {
+func (v Var) ReadIdxBytes(idx []uint64) (val byte, err error) {
 	err = newError(C.nc_get_var1_text(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxBytes sets a value via its index position
-func (v Var) WriteIdxBytes(idx []int, val byte) (err error) {
+func (v Var) WriteIdxBytes(idx []uint64, val byte) (err error) {
 	err = newError(C.nc_put_var1_text(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadBytesIdx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := byte(i + 10)
 		val, _ := v.ReadIdxBytes(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadBytesIdx(v Var, n uint64) error {
 func testWriteBytesIdx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxBytes(coord, byte(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxBytes(coord)
 		if val != byte(i) {

--- a/netcdf/nc_char.go
+++ b/netcdf/nc_char.go
@@ -55,15 +55,15 @@ func (a Attr) ReadBytes(val []byte) (err error) {
 	return
 }
 
-// ReadIdxBytes returns a value via index position
-func (v Var) ReadIdxBytes(idx []uint64) (val byte, err error) {
+// ReadBytesAt returns a value via index position
+func (v Var) ReadBytesAt(idx []uint64) (val byte, err error) {
 	err = newError(C.nc_get_var1_text(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxBytes sets a value via its index position
-func (v Var) WriteIdxBytes(idx []uint64, val byte) (err error) {
+// WriteBytesAt sets a value via its index position
+func (v Var) WriteBytesAt(idx []uint64, val byte) (err error) {
 	err = newError(C.nc_put_var1_text(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadBytes(v Var, n uint64) error {
 	return nil
 }
 
-func testReadBytesIdx(v Var, n uint64) error {
+func testReadBytesAt(v Var, n uint64) error {
 	data := make([]byte, n)
 	if err := v.ReadBytes(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadBytesIdx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := byte(i + 10)
-		val, _ := v.ReadIdxBytes(coords)
+		val, _ := v.ReadBytesAt(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadBytesIdx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteBytesIdx(v Var, n uint64) error {
+func testWriteBytesAt(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteBytesIdx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxBytes(coord, byte(i))
+		v.WriteBytesAt(coord, byte(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxBytes(coord)
+		val, _ := v.ReadBytesAt(coord)
 		if val != byte(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_double.go
+++ b/netcdf/nc_double.go
@@ -55,6 +55,20 @@ func (a Attr) ReadFloat64s(val []float64) (err error) {
 	return
 }
 
+// ReadIdxFloat64 returns a value via index position
+func (v Var) ReadIdxFloat64(idx []int) (val float64, err error) {
+	err = newError(C.nc_get_var1_double(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxFloat64 sets a value via its index position
+func (v Var) WriteIdxFloat64(idx []int, val float64) (err error) {
+	err = newError(C.nc_put_var1_double(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
+	return
+}
+
 // Float64sReader is a interface that allows reading a sequence of values of fixed length.
 type Float64sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadFloat64s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := float64(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_double.go
+++ b/netcdf/nc_double.go
@@ -56,14 +56,14 @@ func (a Attr) ReadFloat64s(val []float64) (err error) {
 }
 
 // ReadIdxFloat64 returns a value via index position
-func (v Var) ReadIdxFloat64(idx []int) (val float64, err error) {
+func (v Var) ReadIdxFloat64(idx []uint64) (val float64, err error) {
 	err = newError(C.nc_get_var1_double(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxFloat64 sets a value via its index position
-func (v Var) WriteIdxFloat64(idx []int, val float64) (err error) {
+func (v Var) WriteIdxFloat64(idx []uint64, val float64) (err error) {
 	err = newError(C.nc_put_var1_double(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadFloat64Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := float64(i + 10)
 		val, _ := v.ReadIdxFloat64(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadFloat64Idx(v Var, n uint64) error {
 func testWriteFloat64Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxFloat64(coord, float64(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxFloat64(coord)
 		if val != float64(i) {

--- a/netcdf/nc_double.go
+++ b/netcdf/nc_double.go
@@ -112,7 +112,7 @@ func testReadFloat64s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadIdx(v Var, n uint64) error {
+func testReadFloat64Idx(v Var, n uint64) error {
 	data := make([]float64, n)
 	if err := v.ReadFloat64s(data); err != nil {
 		return err
@@ -128,6 +128,28 @@ func testReadIdx(v Var, n uint64) error {
 		val, _ := v.ReadIdxFloat64(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteFloat64Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxFloat64(coord, float64(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxFloat64(coord)
+		if val != float64(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}
 	}
 	return nil

--- a/netcdf/nc_double.go
+++ b/netcdf/nc_double.go
@@ -111,3 +111,24 @@ func testReadFloat64s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadIdx(v Var, n uint64) error {
+	data := make([]float64, n)
+	if err := v.ReadFloat64s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := float64(i + 10)
+		val, _ := v.ReadIdxFloat64(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_double.go
+++ b/netcdf/nc_double.go
@@ -55,15 +55,15 @@ func (a Attr) ReadFloat64s(val []float64) (err error) {
 	return
 }
 
-// ReadIdxFloat64 returns a value via index position
-func (v Var) ReadIdxFloat64(idx []uint64) (val float64, err error) {
+// ReadFloat64At returns a value via index position
+func (v Var) ReadFloat64At(idx []uint64) (val float64, err error) {
 	err = newError(C.nc_get_var1_double(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxFloat64 sets a value via its index position
-func (v Var) WriteIdxFloat64(idx []uint64, val float64) (err error) {
+// WriteFloat64At sets a value via its index position
+func (v Var) WriteFloat64At(idx []uint64, val float64) (err error) {
 	err = newError(C.nc_put_var1_double(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadFloat64s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadFloat64Idx(v Var, n uint64) error {
+func testReadFloat64At(v Var, n uint64) error {
 	data := make([]float64, n)
 	if err := v.ReadFloat64s(data); err != nil {
 		return err
@@ -120,16 +120,16 @@ func testReadFloat64Idx(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := float64(i + 10)
-		val, _ := v.ReadIdxFloat64(coords)
-		if val != data[i] {
+		expected := data[i]
+		val, _ := v.ReadFloat64At(coords)
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}
 	return nil
 }
 
-func testWriteFloat64Idx(v Var, n uint64) error {
+func testWriteFloat64At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteFloat64Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxFloat64(coord, float64(i))
+		v.WriteFloat64At(coord, float64(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxFloat64(coord)
+		val, _ := v.ReadFloat64At(coord)
 		if val != float64(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_float.go
+++ b/netcdf/nc_float.go
@@ -56,14 +56,14 @@ func (a Attr) ReadFloat32s(val []float32) (err error) {
 }
 
 // ReadIdxFloat32 returns a value via index position
-func (v Var) ReadIdxFloat32(idx []int) (val float32, err error) {
+func (v Var) ReadIdxFloat32(idx []uint64) (val float32, err error) {
 	err = newError(C.nc_get_var1_float(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxFloat32 sets a value via its index position
-func (v Var) WriteIdxFloat32(idx []int, val float32) (err error) {
+func (v Var) WriteIdxFloat32(idx []uint64, val float32) (err error) {
 	err = newError(C.nc_put_var1_float(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadFloat32Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := float32(i + 10)
 		val, _ := v.ReadIdxFloat32(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadFloat32Idx(v Var, n uint64) error {
 func testWriteFloat32Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxFloat32(coord, float32(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxFloat32(coord)
 		if val != float32(i) {

--- a/netcdf/nc_float.go
+++ b/netcdf/nc_float.go
@@ -55,15 +55,15 @@ func (a Attr) ReadFloat32s(val []float32) (err error) {
 	return
 }
 
-// ReadIdxFloat32 returns a value via index position
-func (v Var) ReadIdxFloat32(idx []uint64) (val float32, err error) {
+// ReadFloat32At returns a value via index position
+func (v Var) ReadFloat32At(idx []uint64) (val float32, err error) {
 	err = newError(C.nc_get_var1_float(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxFloat32 sets a value via its index position
-func (v Var) WriteIdxFloat32(idx []uint64, val float32) (err error) {
+// WriteFloat32At sets a value via its index position
+func (v Var) WriteFloat32At(idx []uint64, val float32) (err error) {
 	err = newError(C.nc_put_var1_float(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadFloat32s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadFloat32Idx(v Var, n uint64) error {
+func testReadFloat32At(v Var, n uint64) error {
 	data := make([]float32, n)
 	if err := v.ReadFloat32s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadFloat32Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := float32(i + 10)
-		val, _ := v.ReadIdxFloat32(coords)
+		val, _ := v.ReadFloat32At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadFloat32Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteFloat32Idx(v Var, n uint64) error {
+func testWriteFloat32At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteFloat32Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxFloat32(coord, float32(i))
+		v.WriteFloat32At(coord, float32(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxFloat32(coord)
+		val, _ := v.ReadFloat32At(coord)
 		if val != float32(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_float.go
+++ b/netcdf/nc_float.go
@@ -55,6 +55,20 @@ func (a Attr) ReadFloat32s(val []float32) (err error) {
 	return
 }
 
+// ReadIdxFloat32 returns a value via index position
+func (v Var) ReadIdxFloat32(idx []int) (val float32, err error) {
+	err = newError(C.nc_get_var1_float(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxFloat32 sets a value via its index position
+func (v Var) WriteIdxFloat32(idx []int, val float32) (err error) {
+	err = newError(C.nc_put_var1_float(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
+	return
+}
+
 // Float32sReader is a interface that allows reading a sequence of values of fixed length.
 type Float32sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadFloat32s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := float32(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_float.go
+++ b/netcdf/nc_float.go
@@ -111,3 +111,46 @@ func testReadFloat32s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadFloat32Idx(v Var, n uint64) error {
+	data := make([]float32, n)
+	if err := v.ReadFloat32s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := float32(i + 10)
+		val, _ := v.ReadIdxFloat32(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteFloat32Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxFloat32(coord, float32(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxFloat32(coord)
+		if val != float32(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_int.go
+++ b/netcdf/nc_int.go
@@ -111,3 +111,46 @@ func testReadInt32s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadInt32Idx(v Var, n uint64) error {
+	data := make([]int32, n)
+	if err := v.ReadInt32s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := int32(i + 10)
+		val, _ := v.ReadIdxInt32(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteInt32Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxInt32(coord, int32(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxInt32(coord)
+		if val != int32(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_int.go
+++ b/netcdf/nc_int.go
@@ -55,6 +55,20 @@ func (a Attr) ReadInt32s(val []int32) (err error) {
 	return
 }
 
+// ReadIdxInt32 returns a value via index position
+func (v Var) ReadIdxInt32(idx []int) (val int32, err error) {
+	err = newError(C.nc_get_var1_int(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxInt32 sets a value via its index position
+func (v Var) WriteIdxInt32(idx []int, val int32) (err error) {
+	err = newError(C.nc_put_var1_int(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
+	return
+}
+
 // Int32sReader is a interface that allows reading a sequence of values of fixed length.
 type Int32sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadInt32s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := int32(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_int.go
+++ b/netcdf/nc_int.go
@@ -55,15 +55,15 @@ func (a Attr) ReadInt32s(val []int32) (err error) {
 	return
 }
 
-// ReadIdxInt32 returns a value via index position
-func (v Var) ReadIdxInt32(idx []uint64) (val int32, err error) {
+// ReadInt32At returns a value via index position
+func (v Var) ReadInt32At(idx []uint64) (val int32, err error) {
 	err = newError(C.nc_get_var1_int(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxInt32 sets a value via its index position
-func (v Var) WriteIdxInt32(idx []uint64, val int32) (err error) {
+// WriteInt32At sets a value via its index position
+func (v Var) WriteInt32At(idx []uint64, val int32) (err error) {
 	err = newError(C.nc_put_var1_int(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadInt32s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadInt32Idx(v Var, n uint64) error {
+func testReadInt32At(v Var, n uint64) error {
 	data := make([]int32, n)
 	if err := v.ReadInt32s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadInt32Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int32(i + 10)
-		val, _ := v.ReadIdxInt32(coords)
+		val, _ := v.ReadInt32At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadInt32Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteInt32Idx(v Var, n uint64) error {
+func testWriteInt32At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteInt32Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxInt32(coord, int32(i))
+		v.WriteInt32At(coord, int32(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxInt32(coord)
+		val, _ := v.ReadInt32At(coord)
 		if val != int32(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_int.go
+++ b/netcdf/nc_int.go
@@ -56,14 +56,14 @@ func (a Attr) ReadInt32s(val []int32) (err error) {
 }
 
 // ReadIdxInt32 returns a value via index position
-func (v Var) ReadIdxInt32(idx []int) (val int32, err error) {
+func (v Var) ReadIdxInt32(idx []uint64) (val int32, err error) {
 	err = newError(C.nc_get_var1_int(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxInt32 sets a value via its index position
-func (v Var) WriteIdxInt32(idx []int, val int32) (err error) {
+func (v Var) WriteIdxInt32(idx []uint64, val int32) (err error) {
 	err = newError(C.nc_put_var1_int(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadInt32Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int32(i + 10)
 		val, _ := v.ReadIdxInt32(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadInt32Idx(v Var, n uint64) error {
 func testWriteInt32Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxInt32(coord, int32(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxInt32(coord)
 		if val != int32(i) {

--- a/netcdf/nc_int64.go
+++ b/netcdf/nc_int64.go
@@ -55,6 +55,20 @@ func (a Attr) ReadInt64s(val []int64) (err error) {
 	return
 }
 
+// ReadIdxInt64 returns a value via index position
+func (v Var) ReadIdxInt64(idx []int) (val int64, err error) {
+	err = newError(C.nc_get_var1_longlong(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxInt64 sets a value via its index position
+func (v Var) WriteIdxInt64(idx []int, val int64) (err error) {
+	err = newError(C.nc_put_var1_longlong(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
+	return
+}
+
 // Int64sReader is a interface that allows reading a sequence of values of fixed length.
 type Int64sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadInt64s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := int64(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_int64.go
+++ b/netcdf/nc_int64.go
@@ -55,15 +55,15 @@ func (a Attr) ReadInt64s(val []int64) (err error) {
 	return
 }
 
-// ReadIdxInt64 returns a value via index position
-func (v Var) ReadIdxInt64(idx []uint64) (val int64, err error) {
+// ReadInt64At returns a value via index position
+func (v Var) ReadInt64At(idx []uint64) (val int64, err error) {
 	err = newError(C.nc_get_var1_longlong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxInt64 sets a value via its index position
-func (v Var) WriteIdxInt64(idx []uint64, val int64) (err error) {
+// WriteInt64At sets a value via its index position
+func (v Var) WriteInt64At(idx []uint64, val int64) (err error) {
 	err = newError(C.nc_put_var1_longlong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadInt64s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadInt64Idx(v Var, n uint64) error {
+func testReadInt64At(v Var, n uint64) error {
 	data := make([]int64, n)
 	if err := v.ReadInt64s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadInt64Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int64(i + 10)
-		val, _ := v.ReadIdxInt64(coords)
+		val, _ := v.ReadInt64At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadInt64Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteInt64Idx(v Var, n uint64) error {
+func testWriteInt64At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteInt64Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxInt64(coord, int64(i))
+		v.WriteInt64At(coord, int64(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxInt64(coord)
+		val, _ := v.ReadInt64At(coord)
 		if val != int64(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_int64.go
+++ b/netcdf/nc_int64.go
@@ -111,3 +111,46 @@ func testReadInt64s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadInt64Idx(v Var, n uint64) error {
+	data := make([]int64, n)
+	if err := v.ReadInt64s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := int64(i + 10)
+		val, _ := v.ReadIdxInt64(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteInt64Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxInt64(coord, int64(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxInt64(coord)
+		if val != int64(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_int64.go
+++ b/netcdf/nc_int64.go
@@ -56,14 +56,14 @@ func (a Attr) ReadInt64s(val []int64) (err error) {
 }
 
 // ReadIdxInt64 returns a value via index position
-func (v Var) ReadIdxInt64(idx []int) (val int64, err error) {
+func (v Var) ReadIdxInt64(idx []uint64) (val int64, err error) {
 	err = newError(C.nc_get_var1_longlong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxInt64 sets a value via its index position
-func (v Var) WriteIdxInt64(idx []int, val int64) (err error) {
+func (v Var) WriteIdxInt64(idx []uint64, val int64) (err error) {
 	err = newError(C.nc_put_var1_longlong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadInt64Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int64(i + 10)
 		val, _ := v.ReadIdxInt64(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadInt64Idx(v Var, n uint64) error {
 func testWriteInt64Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxInt64(coord, int64(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxInt64(coord)
 		if val != int64(i) {

--- a/netcdf/nc_short.go
+++ b/netcdf/nc_short.go
@@ -55,6 +55,20 @@ func (a Attr) ReadInt16s(val []int16) (err error) {
 	return
 }
 
+// ReadIdxInt16 returns a value via index position
+func (v Var) ReadIdxInt16(idx []int) (val int16, err error) {
+	err = newError(C.nc_get_var1_short(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxInt16 sets a value via its index position
+func (v Var) WriteIdxInt16(idx []int, val int16) (err error) {
+	err = newError(C.nc_put_var1_short(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
+	return
+}
+
 // Int16sReader is a interface that allows reading a sequence of values of fixed length.
 type Int16sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadInt16s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := int16(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_short.go
+++ b/netcdf/nc_short.go
@@ -55,15 +55,15 @@ func (a Attr) ReadInt16s(val []int16) (err error) {
 	return
 }
 
-// ReadIdxInt16 returns a value via index position
-func (v Var) ReadIdxInt16(idx []uint64) (val int16, err error) {
+// ReadInt16At returns a value via index position
+func (v Var) ReadInt16At(idx []uint64) (val int16, err error) {
 	err = newError(C.nc_get_var1_short(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxInt16 sets a value via its index position
-func (v Var) WriteIdxInt16(idx []uint64, val int16) (err error) {
+// WriteInt16At sets a value via its index position
+func (v Var) WriteInt16At(idx []uint64, val int16) (err error) {
 	err = newError(C.nc_put_var1_short(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadInt16s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadInt16Idx(v Var, n uint64) error {
+func testReadInt16At(v Var, n uint64) error {
 	data := make([]int16, n)
 	if err := v.ReadInt16s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadInt16Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int16(i + 10)
-		val, _ := v.ReadIdxInt16(coords)
+		val, _ := v.ReadInt16At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadInt16Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteInt16Idx(v Var, n uint64) error {
+func testWriteInt16At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteInt16Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxInt16(coord, int16(i))
+		v.WriteInt16At(coord, int16(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxInt16(coord)
+		val, _ := v.ReadInt16At(coord)
 		if val != int16(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_short.go
+++ b/netcdf/nc_short.go
@@ -111,3 +111,46 @@ func testReadInt16s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadInt16Idx(v Var, n uint64) error {
+	data := make([]int16, n)
+	if err := v.ReadInt16s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := int16(i + 10)
+		val, _ := v.ReadIdxInt16(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteInt16Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxInt16(coord, int16(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxInt16(coord)
+		if val != int16(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_short.go
+++ b/netcdf/nc_short.go
@@ -56,14 +56,14 @@ func (a Attr) ReadInt16s(val []int16) (err error) {
 }
 
 // ReadIdxInt16 returns a value via index position
-func (v Var) ReadIdxInt16(idx []int) (val int16, err error) {
+func (v Var) ReadIdxInt16(idx []uint64) (val int16, err error) {
 	err = newError(C.nc_get_var1_short(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxInt16 sets a value via its index position
-func (v Var) WriteIdxInt16(idx []int, val int16) (err error) {
+func (v Var) WriteIdxInt16(idx []uint64, val int16) (err error) {
 	err = newError(C.nc_put_var1_short(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadInt16Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := int16(i + 10)
 		val, _ := v.ReadIdxInt16(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadInt16Idx(v Var, n uint64) error {
 func testWriteInt16Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxInt16(coord, int16(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxInt16(coord)
 		if val != int16(i) {

--- a/netcdf/nc_ubyte.go
+++ b/netcdf/nc_ubyte.go
@@ -56,14 +56,14 @@ func (a Attr) ReadUint8s(val []uint8) (err error) {
 }
 
 // ReadIdxUint8 returns a value via index position
-func (v Var) ReadIdxUint8(idx []int) (val uint8, err error) {
+func (v Var) ReadIdxUint8(idx []uint64) (val uint8, err error) {
 	err = newError(C.nc_get_var1_uchar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxUint8 sets a value via its index position
-func (v Var) WriteIdxUint8(idx []int, val uint8) (err error) {
+func (v Var) WriteIdxUint8(idx []uint64, val uint8) (err error) {
 	err = newError(C.nc_put_var1_uchar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadUint8Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint8(i + 10)
 		val, _ := v.ReadIdxUint8(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadUint8Idx(v Var, n uint64) error {
 func testWriteUint8Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxUint8(coord, uint8(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxUint8(coord)
 		if val != uint8(i) {

--- a/netcdf/nc_ubyte.go
+++ b/netcdf/nc_ubyte.go
@@ -55,15 +55,15 @@ func (a Attr) ReadUint8s(val []uint8) (err error) {
 	return
 }
 
-// ReadIdxUint8 returns a value via index position
-func (v Var) ReadIdxUint8(idx []uint64) (val uint8, err error) {
+// ReadUint8At returns a value via index position
+func (v Var) ReadUint8At(idx []uint64) (val uint8, err error) {
 	err = newError(C.nc_get_var1_uchar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxUint8 sets a value via its index position
-func (v Var) WriteIdxUint8(idx []uint64, val uint8) (err error) {
+// WriteUint8At sets a value via its index position
+func (v Var) WriteUint8At(idx []uint64, val uint8) (err error) {
 	err = newError(C.nc_put_var1_uchar(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadUint8s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadUint8Idx(v Var, n uint64) error {
+func testReadUint8At(v Var, n uint64) error {
 	data := make([]uint8, n)
 	if err := v.ReadUint8s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadUint8Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint8(i + 10)
-		val, _ := v.ReadIdxUint8(coords)
+		val, _ := v.ReadUint8At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadUint8Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteUint8Idx(v Var, n uint64) error {
+func testWriteUint8At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteUint8Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxUint8(coord, uint8(i))
+		v.WriteUint8At(coord, uint8(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxUint8(coord)
+		val, _ := v.ReadUint8At(coord)
 		if val != uint8(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_ubyte.go
+++ b/netcdf/nc_ubyte.go
@@ -55,6 +55,20 @@ func (a Attr) ReadUint8s(val []uint8) (err error) {
 	return
 }
 
+// ReadIdxUint8 returns a value via index position
+func (v Var) ReadIdxUint8(idx []int) (val uint8, err error) {
+	err = newError(C.nc_get_var1_uchar(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxUint8 sets a value via its index position
+func (v Var) WriteIdxUint8(idx []int, val uint8) (err error) {
+	err = newError(C.nc_put_var1_uchar(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
+	return
+}
+
 // Uint8sReader is a interface that allows reading a sequence of values of fixed length.
 type Uint8sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadUint8s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := uint8(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_ubyte.go
+++ b/netcdf/nc_ubyte.go
@@ -111,3 +111,46 @@ func testReadUint8s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadUint8Idx(v Var, n uint64) error {
+	data := make([]uint8, n)
+	if err := v.ReadUint8s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := uint8(i + 10)
+		val, _ := v.ReadIdxUint8(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteUint8Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxUint8(coord, uint8(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxUint8(coord)
+		if val != uint8(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_uint.go
+++ b/netcdf/nc_uint.go
@@ -56,14 +56,14 @@ func (a Attr) ReadUint32s(val []uint32) (err error) {
 }
 
 // ReadIdxUint32 returns a value via index position
-func (v Var) ReadIdxUint32(idx []int) (val uint32, err error) {
+func (v Var) ReadIdxUint32(idx []uint64) (val uint32, err error) {
 	err = newError(C.nc_get_var1_uint(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxUint32 sets a value via its index position
-func (v Var) WriteIdxUint32(idx []int, val uint32) (err error) {
+func (v Var) WriteIdxUint32(idx []uint64, val uint32) (err error) {
 	err = newError(C.nc_put_var1_uint(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadUint32Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint32(i + 10)
 		val, _ := v.ReadIdxUint32(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadUint32Idx(v Var, n uint64) error {
 func testWriteUint32Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxUint32(coord, uint32(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxUint32(coord)
 		if val != uint32(i) {

--- a/netcdf/nc_uint.go
+++ b/netcdf/nc_uint.go
@@ -111,3 +111,46 @@ func testReadUint32s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadUint32Idx(v Var, n uint64) error {
+	data := make([]uint32, n)
+	if err := v.ReadUint32s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := uint32(i + 10)
+		val, _ := v.ReadIdxUint32(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteUint32Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxUint32(coord, uint32(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxUint32(coord)
+		if val != uint32(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_uint.go
+++ b/netcdf/nc_uint.go
@@ -55,6 +55,20 @@ func (a Attr) ReadUint32s(val []uint32) (err error) {
 	return
 }
 
+// ReadIdxUint32 returns a value via index position
+func (v Var) ReadIdxUint32(idx []int) (val uint32, err error) {
+	err = newError(C.nc_get_var1_uint(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxUint32 sets a value via its index position
+func (v Var) WriteIdxUint32(idx []int, val uint32) (err error) {
+	err = newError(C.nc_put_var1_uint(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
+	return
+}
+
 // Uint32sReader is a interface that allows reading a sequence of values of fixed length.
 type Uint32sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadUint32s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := uint32(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_uint.go
+++ b/netcdf/nc_uint.go
@@ -55,15 +55,15 @@ func (a Attr) ReadUint32s(val []uint32) (err error) {
 	return
 }
 
-// ReadIdxUint32 returns a value via index position
-func (v Var) ReadIdxUint32(idx []uint64) (val uint32, err error) {
+// ReadUint32At returns a value via index position
+func (v Var) ReadUint32At(idx []uint64) (val uint32, err error) {
 	err = newError(C.nc_get_var1_uint(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxUint32 sets a value via its index position
-func (v Var) WriteIdxUint32(idx []uint64, val uint32) (err error) {
+// WriteUint32At sets a value via its index position
+func (v Var) WriteUint32At(idx []uint64, val uint32) (err error) {
 	err = newError(C.nc_put_var1_uint(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadUint32s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadUint32Idx(v Var, n uint64) error {
+func testReadUint32At(v Var, n uint64) error {
 	data := make([]uint32, n)
 	if err := v.ReadUint32s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadUint32Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint32(i + 10)
-		val, _ := v.ReadIdxUint32(coords)
+		val, _ := v.ReadUint32At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadUint32Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteUint32Idx(v Var, n uint64) error {
+func testWriteUint32At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteUint32Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxUint32(coord, uint32(i))
+		v.WriteUint32At(coord, uint32(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxUint32(coord)
+		val, _ := v.ReadUint32At(coord)
 		if val != uint32(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_uint64.go
+++ b/netcdf/nc_uint64.go
@@ -111,3 +111,46 @@ func testReadUint64s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadUint64Idx(v Var, n uint64) error {
+	data := make([]uint64, n)
+	if err := v.ReadUint64s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := uint64(i + 10)
+		val, _ := v.ReadIdxUint64(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteUint64Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxUint64(coord, uint64(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxUint64(coord)
+		if val != uint64(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_uint64.go
+++ b/netcdf/nc_uint64.go
@@ -55,6 +55,20 @@ func (a Attr) ReadUint64s(val []uint64) (err error) {
 	return
 }
 
+// ReadIdxUint64 returns a value via index position
+func (v Var) ReadIdxUint64(idx []int) (val uint64, err error) {
+	err = newError(C.nc_get_var1_ulonglong(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxUint64 sets a value via its index position
+func (v Var) WriteIdxUint64(idx []int, val uint64) (err error) {
+	err = newError(C.nc_put_var1_ulonglong(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
+	return
+}
+
 // Uint64sReader is a interface that allows reading a sequence of values of fixed length.
 type Uint64sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadUint64s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := uint64(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/nc_uint64.go
+++ b/netcdf/nc_uint64.go
@@ -56,14 +56,14 @@ func (a Attr) ReadUint64s(val []uint64) (err error) {
 }
 
 // ReadIdxUint64 returns a value via index position
-func (v Var) ReadIdxUint64(idx []int) (val uint64, err error) {
+func (v Var) ReadIdxUint64(idx []uint64) (val uint64, err error) {
 	err = newError(C.nc_get_var1_ulonglong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxUint64 sets a value via its index position
-func (v Var) WriteIdxUint64(idx []int, val uint64) (err error) {
+func (v Var) WriteIdxUint64(idx []uint64, val uint64) (err error) {
 	err = newError(C.nc_put_var1_ulonglong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadUint64Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint64(i + 10)
 		val, _ := v.ReadIdxUint64(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadUint64Idx(v Var, n uint64) error {
 func testWriteUint64Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxUint64(coord, uint64(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxUint64(coord)
 		if val != uint64(i) {

--- a/netcdf/nc_uint64.go
+++ b/netcdf/nc_uint64.go
@@ -55,15 +55,15 @@ func (a Attr) ReadUint64s(val []uint64) (err error) {
 	return
 }
 
-// ReadIdxUint64 returns a value via index position
-func (v Var) ReadIdxUint64(idx []uint64) (val uint64, err error) {
+// ReadUint64At returns a value via index position
+func (v Var) ReadUint64At(idx []uint64) (val uint64, err error) {
 	err = newError(C.nc_get_var1_ulonglong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxUint64 sets a value via its index position
-func (v Var) WriteIdxUint64(idx []uint64, val uint64) (err error) {
+// WriteUint64At sets a value via its index position
+func (v Var) WriteUint64At(idx []uint64, val uint64) (err error) {
 	err = newError(C.nc_put_var1_ulonglong(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadUint64s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadUint64Idx(v Var, n uint64) error {
+func testReadUint64At(v Var, n uint64) error {
 	data := make([]uint64, n)
 	if err := v.ReadUint64s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadUint64Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint64(i + 10)
-		val, _ := v.ReadIdxUint64(coords)
+		val, _ := v.ReadUint64At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadUint64Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteUint64Idx(v Var, n uint64) error {
+func testWriteUint64At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteUint64Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxUint64(coord, uint64(i))
+		v.WriteUint64At(coord, uint64(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxUint64(coord)
+		val, _ := v.ReadUint64At(coord)
 		if val != uint64(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_ushort.go
+++ b/netcdf/nc_ushort.go
@@ -56,14 +56,14 @@ func (a Attr) ReadUint16s(val []uint16) (err error) {
 }
 
 // ReadIdxUint16 returns a value via index position
-func (v Var) ReadIdxUint16(idx []int) (val uint16, err error) {
+func (v Var) ReadIdxUint16(idx []uint64) (val uint16, err error) {
 	err = newError(C.nc_get_var1_ushort(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteIdxUint16 sets a value via its index position
-func (v Var) WriteIdxUint16(idx []int, val uint16) (err error) {
+func (v Var) WriteIdxUint16(idx []uint64, val uint16) (err error) {
 	err = newError(C.nc_put_var1_ushort(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
 	return
@@ -119,11 +119,7 @@ func testReadUint16Idx(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
-		var shapeint = make([]int, len(shape))
-		for i, v := range shape {
-			shapeint[i] = int(v)
-		}
-		coords, _ := UnravelIndex(i, shapeint)
+		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint16(i + 10)
 		val, _ := v.ReadIdxUint16(coords)
 		if val != data[i] {
@@ -136,16 +132,16 @@ func testReadUint16Idx(v Var, n uint64) error {
 func testWriteUint16Idx(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
-	coord := make([]int, ndim)
+	coord := make([]uint64, ndim)
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		v.WriteIdxUint16(coord, uint16(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
-			coord[k] = i
+			coord[k] = uint64(i)
 		}
 		val, _ := v.ReadIdxUint16(coord)
 		if val != uint16(i) {

--- a/netcdf/nc_ushort.go
+++ b/netcdf/nc_ushort.go
@@ -55,15 +55,15 @@ func (a Attr) ReadUint16s(val []uint16) (err error) {
 	return
 }
 
-// ReadIdxUint16 returns a value via index position
-func (v Var) ReadIdxUint16(idx []uint64) (val uint16, err error) {
+// ReadUint16At returns a value via index position
+func (v Var) ReadUint16At(idx []uint64) (val uint16, err error) {
 	err = newError(C.nc_get_var1_ushort(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
 	return
 }
 
-// WriteIdxUint16 sets a value via its index position
-func (v Var) WriteIdxUint16(idx []uint64, val uint16) (err error) {
+// WriteUint16At sets a value via its index position
+func (v Var) WriteUint16At(idx []uint64, val uint16) (err error) {
 	err = newError(C.nc_put_var1_ushort(C.int(v.ds), C.int(v.id),
 		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
 	return
@@ -112,7 +112,7 @@ func testReadUint16s(v Var, n uint64) error {
 	return nil
 }
 
-func testReadUint16Idx(v Var, n uint64) error {
+func testReadUint16At(v Var, n uint64) error {
 	data := make([]uint16, n)
 	if err := v.ReadUint16s(data); err != nil {
 		return err
@@ -121,7 +121,7 @@ func testReadUint16Idx(v Var, n uint64) error {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
 		expected := uint16(i + 10)
-		val, _ := v.ReadIdxUint16(coords)
+		val, _ := v.ReadUint16At(coords)
 		if val != data[i] {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
@@ -129,7 +129,7 @@ func testReadUint16Idx(v Var, n uint64) error {
 	return nil
 }
 
-func testWriteUint16Idx(v Var, n uint64) error {
+func testWriteUint16At(v Var, n uint64) error {
 	shape, _ := v.LenDims()
 	ndim := len(shape)
 	coord := make([]uint64, ndim)
@@ -137,13 +137,13 @@ func testWriteUint16Idx(v Var, n uint64) error {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		v.WriteIdxUint16(coord, uint16(i))
+		v.WriteUint16At(coord, uint16(i))
 	}
 	for i := 0; i < ndim; i++ {
 		for k := 0; k < ndim; k++ {
 			coord[k] = uint64(i)
 		}
-		val, _ := v.ReadIdxUint16(coord)
+		val, _ := v.ReadUint16At(coord)
 		if val != uint16(i) {
 			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
 		}

--- a/netcdf/nc_ushort.go
+++ b/netcdf/nc_ushort.go
@@ -111,3 +111,46 @@ func testReadUint16s(v Var, n uint64) error {
 	}
 	return nil
 }
+
+func testReadUint16Idx(v Var, n uint64) error {
+	data := make([]uint16, n)
+	if err := v.ReadUint16s(data); err != nil {
+		return err
+	}
+	for i := 0; i < int(n); i++ {
+		shape, _ := v.LenDims()
+		var shapeint = make([]int, len(shape))
+		for i, v := range shape {
+			shapeint[i] = int(v)
+		}
+		coords, _ := UnravelIndex(i, shapeint)
+		expected := uint16(i + 10)
+		val, _ := v.ReadIdxUint16(coords)
+		if val != data[i] {
+			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
+		}
+	}
+	return nil
+}
+
+func testWriteUint16Idx(v Var, n uint64) error {
+	shape, _ := v.LenDims()
+	ndim := len(shape)
+	coord := make([]int, ndim)
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		v.WriteIdxUint16(coord, uint16(i))
+	}
+	for i := 0; i < ndim; i++ {
+		for k := 0; k < ndim; k++ {
+			coord[k] = i
+		}
+		val, _ := v.ReadIdxUint16(coord)
+		if val != uint16(i) {
+			return fmt.Errorf("data at position %v is %v; expected %v", coord, val, int(i))
+		}
+	}
+	return nil
+}

--- a/netcdf/nc_ushort.go
+++ b/netcdf/nc_ushort.go
@@ -55,6 +55,20 @@ func (a Attr) ReadUint16s(val []uint16) (err error) {
 	return
 }
 
+// ReadIdxUint16 returns a value via index position
+func (v Var) ReadIdxUint16(idx []int) (val uint16, err error) {
+	err = newError(C.nc_get_var1_ushort(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
+	return
+}
+
+// WriteIdxUint16 sets a value via its index position
+func (v Var) WriteIdxUint16(idx []int, val uint16) (err error) {
+	err = newError(C.nc_put_var1_ushort(C.int(v.ds), C.int(v.id),
+		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
+	return
+}
+
 // Uint16sReader is a interface that allows reading a sequence of values of fixed length.
 type Uint16sReader interface {
 	Len() (n uint64, err error)
@@ -92,7 +106,7 @@ func testReadUint16s(v Var, n uint64) error {
 	}
 	for i := 0; i < int(n); i++ {
 		if val := uint16(i + 10); data[i] != val {
-			return fmt.Errorf("data at position %d is %v; expected %v\n", i, data[i], val)
+			return fmt.Errorf("data at position %d is %v; expected %v", i, data[i], val)
 		}
 	}
 	return nil

--- a/netcdf/netcdf.go
+++ b/netcdf/netcdf.go
@@ -48,10 +48,6 @@ func product(nums []uint64) (prod uint64) {
 
 // UnravelIndex calculates coordinate position based on index
 func UnravelIndex(idx uint64, shape []uint64) ([]uint64, error) {
-	var maxval = product(shape)
-	var ndim = len(shape)
-	var coord = make([]uint64, ndim)
-
 	for _, v := range shape {
 		if v == 0 {
 			return nil, fmt.Errorf("Invalid shape, 0 encountered in shape %v", shape)
@@ -61,6 +57,10 @@ func UnravelIndex(idx uint64, shape []uint64) ([]uint64, error) {
 	if idx > product(shape) {
 		return nil, fmt.Errorf("Index %v > size %v of shape", idx, shape)
 	}
+
+	var maxval = product(shape)
+	var ndim = len(shape)
+	var coord = make([]uint64, ndim)
 
 	for i := 0; i < ndim; i++ {
 		shape[i] = 1

--- a/netcdf/netcdf.go
+++ b/netcdf/netcdf.go
@@ -37,3 +37,36 @@ func okData(a typedArray, t Type, n int) error {
 	}
 	return nil
 }
+
+func product(nums []int) (prod int) {
+	prod = 1
+	for _, i := range nums {
+		prod *= i
+	}
+	return
+}
+
+// UnravelIndex calculates coordinate position based on index
+func UnravelIndex(idx int, shape []int) ([]int, error) {
+	var maxval = product(shape)
+	var ndim = len(shape)
+	var coord = make([]int, ndim)
+
+	for _, v := range shape {
+		if v == 0 {
+			return nil, fmt.Errorf("Invalid shape, 0 encountered in shape %v", shape)
+		}
+	}
+
+	if idx > product(shape) {
+		return nil, fmt.Errorf("Index %v > size %v of shape", idx, shape)
+	}
+
+	for i := 0; i < ndim; i++ {
+		shape[i] = 1
+		maxval = product(shape)
+		coord[i] = int(idx / maxval)
+		idx -= coord[i] * maxval
+	}
+	return coord, nil
+}

--- a/netcdf/netcdf.go
+++ b/netcdf/netcdf.go
@@ -38,7 +38,7 @@ func okData(a typedArray, t Type, n int) error {
 	return nil
 }
 
-func product(nums []int) (prod int) {
+func product(nums []uint64) (prod uint64) {
 	prod = 1
 	for _, i := range nums {
 		prod *= i
@@ -47,10 +47,10 @@ func product(nums []int) (prod int) {
 }
 
 // UnravelIndex calculates coordinate position based on index
-func UnravelIndex(idx int, shape []int) ([]int, error) {
+func UnravelIndex(idx uint64, shape []uint64) ([]uint64, error) {
 	var maxval = product(shape)
 	var ndim = len(shape)
-	var coord = make([]int, ndim)
+	var coord = make([]uint64, ndim)
 
 	for _, v := range shape {
 		if v == 0 {
@@ -65,7 +65,7 @@ func UnravelIndex(idx int, shape []int) ([]int, error) {
 	for i := 0; i < ndim; i++ {
 		shape[i] = 1
 		maxval = product(shape)
-		coord[i] = int(idx / maxval)
+		coord[i] = uint64(idx / maxval)
 		idx -= coord[i] * maxval
 	}
 	return coord, nil


### PR DESCRIPTION
I added the ability to write and read from a netcdf file using the coordinate positions. The C functions `nc_get_var1_<type>` and `and nc_put_var1_<type>` are being used. This concludes all supported methods in the C drivers writing directly to a dataset.