### PR TITLE
Support variables without dimensions.

### DIFF
--- a/netcdf/datasets_test.go
+++ b/netcdf/datasets_test.go
@@ -114,37 +114,29 @@ func (ft *FileTest) getAttrs(t *testing.T, v Var) {
 	}
 }
 
-var fileTests = []FileTest{
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: UINT64,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: INT64,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: DOUBLE,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: UINT,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: INT,
-		Attr: map[string]interface{}{
+func getFileTests() []FileTest {
+	var tests []FileTest
+
+	bases := []FileTest{
+		FileTest{
+			VarName:  "gopher",
+			DimNames: []string{"height", "width"},
+			DimLens:  []uint64{7, 3},
+		},
+		FileTest{
+			VarName:  "gopher",
+			DimNames: []string{"time", "height", "width"},
+			DimLens:  []uint64{12, 7, 3},
+		},
+		FileTest{
+			VarName:  "gopher",
+			DimNames: []string{},
+			DimLens:  []uint64{},
+		},
+	}
+	attrs := []map[string]interface{}{
+		nil,
+		map[string]interface{}{
 			"uint64_test": []uint64{0xFABCFABCFABCFABC, 999, 0, 222},
 			"int64_test":  []int64{0x7ABC7ABC7ABC7ABC, -999, 0, 222},
 			"double_test": []float64{3.14, 1.23, -5.7, 0, 7},
@@ -157,47 +149,22 @@ var fileTests = []FileTest{
 			"byte_test":   []int8{2, 100, -128, 127, -17},
 			"birthday":    "2009-11-10",
 		},
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: FLOAT,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: USHORT,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: SHORT,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: UBYTE,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: BYTE,
-	},
-	{
-		VarName:  "gopher",
-		DimNames: []string{"height", "width"},
-		DimLens:  []uint64{7, 3},
-		DataType: CHAR,
-	},
+	}
+	types := []Type{BYTE, CHAR, SHORT, INT, FLOAT, DOUBLE, UBYTE, USHORT, UINT, INT64, UINT64}
+	for _, test := range bases {
+		for _, attr := range attrs {
+			test.Attr = attr
+			for _, dataType := range types {
+				test.DataType = dataType
+				tests = append(tests, test)
+			}
+		}
+	}
+	return tests
 }
 
 func TestCreate(t *testing.T) {
-	for _, ft := range fileTests {
+	for _, ft := range getFileTests() {
 		f, err := ioutil.TempFile("", "netcdf_test")
 		if err != nil {
 			t.Fatalf("creating temporary file failed: %v\n", err)
@@ -215,7 +182,7 @@ func createFile(t *testing.T, filename string, ft *FileTest) {
 	if err != nil {
 		t.Fatalf("Create failed: %v\n", err)
 	}
-	dims := make([]Dim, 2)
+	dims := make([]Dim, len(ft.DimNames))
 	for i, name := range ft.DimNames {
 		if dims[i], err = f.AddDim(name, ft.DimLens[i]); err != nil {
 			t.Fatalf("PutDim failed: %v\n", err)
@@ -467,7 +434,7 @@ func testWriteFileViaIdx(t *testing.T, filename string, ft *FileTest) {
 	if err != nil {
 		t.Fatalf("Create failed: %v\n", err)
 	}
-	dims := make([]Dim, 2)
+	dims := make([]Dim, len(ft.DimNames))
 	for i, name := range ft.DimNames {
 		if dims[i], err = f.AddDim(name, ft.DimLens[i]); err != nil {
 			t.Fatalf("PutDim failed: %v\n", err)
@@ -587,7 +554,7 @@ func testReadFileViaIdx(t *testing.T, filename string, ft *FileTest) {
 }
 
 func TestAt(t *testing.T) {
-	for _, ft := range fileTests {
+	for _, ft := range getFileTests() {
 		f, err := ioutil.TempFile("", "netcdf_test")
 		if err != nil {
 			t.Fatalf("creating temporary file failed: %v\n", err)

--- a/netcdf/datasets_test.go
+++ b/netcdf/datasets_test.go
@@ -150,7 +150,7 @@ func getFileTests() []FileTest {
 			"birthday":    "2009-11-10",
 		},
 	}
-	types := []Type{BYTE, CHAR, SHORT, INT, FLOAT, DOUBLE, UBYTE, USHORT, UINT, INT64, UINT64}
+	types := []Type{UINT64, INT64, DOUBLE, UINT, INT, FLOAT, USHORT, SHORT, UBYTE, BYTE, CHAR}
 	for _, test := range bases {
 		for _, attr := range attrs {
 			test.Attr = attr

--- a/netcdf/nc_byte.go
+++ b/netcdf/nc_byte.go
@@ -57,15 +57,23 @@ func (a Attr) ReadInt8s(val []int8) (err error) {
 
 // ReadInt8At returns a value via index position
 func (v Var) ReadInt8At(idx []uint64) (val int8, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_schar(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
+		dimPtr, (*C.schar)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteInt8At sets a value via its index position
 func (v Var) WriteInt8At(idx []uint64, val int8) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_schar(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.schar)(unsafe.Pointer(&val))))
+		dimPtr, (*C.schar)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadInt8At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := int8(i + 10)
+		expected := data[i]
 		val, _ := v.ReadInt8At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_char.go
+++ b/netcdf/nc_char.go
@@ -57,15 +57,23 @@ func (a Attr) ReadBytes(val []byte) (err error) {
 
 // ReadBytesAt returns a value via index position
 func (v Var) ReadBytesAt(idx []uint64) (val byte, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_text(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
+		dimPtr, (*C.char)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteBytesAt sets a value via its index position
 func (v Var) WriteBytesAt(idx []uint64, val byte) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_text(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.char)(unsafe.Pointer(&val))))
+		dimPtr, (*C.char)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadBytesAt(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := byte(i + 10)
+		expected := data[i]
 		val, _ := v.ReadBytesAt(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_double.go
+++ b/netcdf/nc_double.go
@@ -57,15 +57,23 @@ func (a Attr) ReadFloat64s(val []float64) (err error) {
 
 // ReadFloat64At returns a value via index position
 func (v Var) ReadFloat64At(idx []uint64) (val float64, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_double(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
+		dimPtr, (*C.double)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteFloat64At sets a value via its index position
 func (v Var) WriteFloat64At(idx []uint64, val float64) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_double(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.double)(unsafe.Pointer(&val))))
+		dimPtr, (*C.double)(unsafe.Pointer(&val))))
 	return
 }
 

--- a/netcdf/nc_float.go
+++ b/netcdf/nc_float.go
@@ -57,15 +57,23 @@ func (a Attr) ReadFloat32s(val []float32) (err error) {
 
 // ReadFloat32At returns a value via index position
 func (v Var) ReadFloat32At(idx []uint64) (val float32, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_float(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
+		dimPtr, (*C.float)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteFloat32At sets a value via its index position
 func (v Var) WriteFloat32At(idx []uint64, val float32) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_float(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.float)(unsafe.Pointer(&val))))
+		dimPtr, (*C.float)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadFloat32At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := float32(i + 10)
+		expected := data[i]
 		val, _ := v.ReadFloat32At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_int.go
+++ b/netcdf/nc_int.go
@@ -57,15 +57,23 @@ func (a Attr) ReadInt32s(val []int32) (err error) {
 
 // ReadInt32At returns a value via index position
 func (v Var) ReadInt32At(idx []uint64) (val int32, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_int(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
+		dimPtr, (*C.int)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteInt32At sets a value via its index position
 func (v Var) WriteInt32At(idx []uint64, val int32) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_int(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.int)(unsafe.Pointer(&val))))
+		dimPtr, (*C.int)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadInt32At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := int32(i + 10)
+		expected := data[i]
 		val, _ := v.ReadInt32At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_int64.go
+++ b/netcdf/nc_int64.go
@@ -57,15 +57,23 @@ func (a Attr) ReadInt64s(val []int64) (err error) {
 
 // ReadInt64At returns a value via index position
 func (v Var) ReadInt64At(idx []uint64) (val int64, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_longlong(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
+		dimPtr, (*C.longlong)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteInt64At sets a value via its index position
 func (v Var) WriteInt64At(idx []uint64, val int64) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_longlong(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.longlong)(unsafe.Pointer(&val))))
+		dimPtr, (*C.longlong)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadInt64At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := int64(i + 10)
+		expected := data[i]
 		val, _ := v.ReadInt64At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_short.go
+++ b/netcdf/nc_short.go
@@ -57,15 +57,23 @@ func (a Attr) ReadInt16s(val []int16) (err error) {
 
 // ReadInt16At returns a value via index position
 func (v Var) ReadInt16At(idx []uint64) (val int16, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_short(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
+		dimPtr, (*C.short)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteInt16At sets a value via its index position
 func (v Var) WriteInt16At(idx []uint64, val int16) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_short(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.short)(unsafe.Pointer(&val))))
+		dimPtr, (*C.short)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadInt16At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := int16(i + 10)
+		expected := data[i]
 		val, _ := v.ReadInt16At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_ubyte.go
+++ b/netcdf/nc_ubyte.go
@@ -57,15 +57,23 @@ func (a Attr) ReadUint8s(val []uint8) (err error) {
 
 // ReadUint8At returns a value via index position
 func (v Var) ReadUint8At(idx []uint64) (val uint8, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_uchar(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
+		dimPtr, (*C.uchar)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteUint8At sets a value via its index position
 func (v Var) WriteUint8At(idx []uint64, val uint8) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_uchar(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uchar)(unsafe.Pointer(&val))))
+		dimPtr, (*C.uchar)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadUint8At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := uint8(i + 10)
+		expected := data[i]
 		val, _ := v.ReadUint8At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_uint.go
+++ b/netcdf/nc_uint.go
@@ -57,15 +57,23 @@ func (a Attr) ReadUint32s(val []uint32) (err error) {
 
 // ReadUint32At returns a value via index position
 func (v Var) ReadUint32At(idx []uint64) (val uint32, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_uint(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
+		dimPtr, (*C.uint)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteUint32At sets a value via its index position
 func (v Var) WriteUint32At(idx []uint64, val uint32) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_uint(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.uint)(unsafe.Pointer(&val))))
+		dimPtr, (*C.uint)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadUint32At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := uint32(i + 10)
+		expected := data[i]
 		val, _ := v.ReadUint32At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_uint64.go
+++ b/netcdf/nc_uint64.go
@@ -57,15 +57,23 @@ func (a Attr) ReadUint64s(val []uint64) (err error) {
 
 // ReadUint64At returns a value via index position
 func (v Var) ReadUint64At(idx []uint64) (val uint64, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_ulonglong(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
+		dimPtr, (*C.ulonglong)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteUint64At sets a value via its index position
 func (v Var) WriteUint64At(idx []uint64, val uint64) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_ulonglong(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ulonglong)(unsafe.Pointer(&val))))
+		dimPtr, (*C.ulonglong)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadUint64At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := uint64(i + 10)
+		expected := data[i]
 		val, _ := v.ReadUint64At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/nc_ushort.go
+++ b/netcdf/nc_ushort.go
@@ -57,15 +57,23 @@ func (a Attr) ReadUint16s(val []uint16) (err error) {
 
 // ReadUint16At returns a value via index position
 func (v Var) ReadUint16At(idx []uint64) (val uint16, err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_get_var1_ushort(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
+		dimPtr, (*C.ushort)(unsafe.Pointer(&val))))
 	return
 }
 
 // WriteUint16At sets a value via its index position
 func (v Var) WriteUint16At(idx []uint64, val uint16) (err error) {
+	var dimPtr *C.size_t
+	if len(idx) > 0 {
+		dimPtr = (*C.size_t)(unsafe.Pointer(&idx[0]))
+	}
 	err = newError(C.nc_put_var1_ushort(C.int(v.ds), C.int(v.id),
-		(*C.size_t)(unsafe.Pointer(&idx[0])), (*C.ushort)(unsafe.Pointer(&val))))
+		dimPtr, (*C.ushort)(unsafe.Pointer(&val))))
 	return
 }
 
@@ -120,9 +128,9 @@ func testReadUint16At(v Var, n uint64) error {
 	for i := 0; i < int(n); i++ {
 		shape, _ := v.LenDims()
 		coords, _ := UnravelIndex(uint64(i), shape)
-		expected := uint16(i + 10)
+		expected := data[i]
 		val, _ := v.ReadUint16At(coords)
-		if val != data[i] {
+		if val != expected {
 			return fmt.Errorf("data at position %v is %v; expected %v", i, val, expected)
 		}
 	}

--- a/netcdf/variables.go
+++ b/netcdf/variables.go
@@ -26,7 +26,7 @@ func (v Var) Dims() (dims []Dim, err error) {
 		return
 	}
 	if ndims == 0 {
-		return make([]Dim, 0), nil
+		return nil, nil
 	}
 	dimids := make([]C.int, ndims)
 	err = newError(C.nc_inq_vardimid(C.int(v.ds), C.int(v.id), &dimids[0]))

--- a/netcdf/variables.go
+++ b/netcdf/variables.go
@@ -26,7 +26,7 @@ func (v Var) Dims() (dims []Dim, err error) {
 		return
 	}
 	if ndims == 0 {
-		return nil, nil
+		return
 	}
 	dimids := make([]C.int, ndims)
 	err = newError(C.nc_inq_vardimid(C.int(v.ds), C.int(v.id), &dimids[0]))


### PR DESCRIPTION
Before this fix, attempting to read or write a variable with no dimensions would cause an "index out of range" error.