### PR TITLE
Expose the dim id

### DIFF
--- a/netcdf/dimensions.go
+++ b/netcdf/dimensions.go
@@ -55,3 +55,7 @@ func (ds Dataset) Dim(name string) (d Dim, err error) {
 	d = Dim{ds, id}
 	return
 }
+
+func (dim Dim) Id() int {
+	return int(dim.id)
+}

--- a/netcdf/dimensions.go
+++ b/netcdf/dimensions.go
@@ -56,6 +56,7 @@ func (ds Dataset) Dim(name string) (d Dim, err error) {
 	return
 }
 
-func (dim Dim) Id() int {
+// ID returns the id of the dimension.
+func (dim Dim) ID() int {
 	return int(dim.id)
 }


### PR DESCRIPTION
In some cases we need to know the order of the ids.
For example when reading a file of `(time,lat,lon)` we get the data in different order than `(lat,lon,time)` in order to handle this we need to know what is the order of the dims 